### PR TITLE
Add NASA-powered area scanning workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Key features:
 - **General object detection** powered by a DETR model capable of identifying a broad range of
   infrastructure and equipment beyond a fixed list of examples.
 - **Persistent storage** of every analysis run, including references to uploaded imagery.
+- **Automatic area scanning** by fetching NASA Earth imagery tiles for a bounding box and analyzing
+  them without preparing archives.
 
 ## Getting started
 
@@ -39,9 +41,13 @@ Key features:
    uvicorn app.main:app --reload
    ```
 
-4. Open <http://localhost:8000> in your browser, upload a satellite image, optionally adjust the
-   analysis prompt, and submit the form. The results table will grow with each analysis, allowing
-   you to revisit previous detections.
+4. Open <http://localhost:8000> in your browser. You can either upload a single satellite image or
+   use the automatic area scan form to request imagery for a latitude/longitude bounding box. The
+   app downloads tiles from the free NASA Earth imagery API, analyzes each tile, and stores the
+   results so you can revisit previous detections.
+
+   The application defaults to the public `DEMO_KEY`, which is limited to roughly 30 requests per
+   hour. Add your own NASA API key via the form for higher throughput or larger areas.
 
 Uploaded imagery is stored under `data/uploads`, and analysis metadata is tracked in the
 `data/satellite_scans.db` SQLite database.

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import logging
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 from fastapi import Depends, FastAPI, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse
@@ -14,12 +16,19 @@ from sqlmodel import Session, select
 from .database import DATA_DIR, get_session, init_db
 from .models import AnalysisResult
 from .services.analyzer import DEFAULT_PROMPT, get_analyzer, serialize_detections
+from .services.imagery import download_nasa_area_tiles
 
 app = FastAPI(title="Satellite Infrastructure Scanner", version="0.1.0")
 
 BASE_DIR = Path(__file__).resolve().parent
 UPLOAD_DIR = DATA_DIR / "uploads"
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+AREA_SCAN_DIR = UPLOAD_DIR / "area_scans"
+AREA_SCAN_DIR.mkdir(parents=True, exist_ok=True)
+
+NASA_API_KEY = os.getenv("NASA_API_KEY", "DEMO_KEY")
+
+logger = logging.getLogger(__name__)
 
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 app.mount("/data/uploads", StaticFiles(directory=UPLOAD_DIR), name="uploads")
@@ -33,25 +42,7 @@ def on_startup() -> None:
 
 @app.get("/", response_class=HTMLResponse)
 def read_root(request: Request, session: Session = Depends(get_session)):
-    statement = select(AnalysisResult).order_by(AnalysisResult.created_at.desc())
-    results: List[AnalysisResult] = session.exec(statement).all()
-    context = {
-        "request": request,
-        "default_prompt": DEFAULT_PROMPT,
-        "results": [
-            {
-                "id": result.id,
-                "image_filename": result.image_filename,
-                "prompt": result.prompt,
-                "caption": result.caption,
-                "unusual_summary": result.unusual_summary,
-                "detections": result.detections(),
-                "created_at": result.created_at,
-            }
-            for result in results
-        ],
-    }
-    return templates.TemplateResponse("index.html", context)
+    return _render_home(request, session)
 
 
 @app.post("/analyze", response_class=HTMLResponse)
@@ -77,27 +68,112 @@ async def analyze(
     session.add(record)
     session.commit()
 
-    statement = select(AnalysisResult).order_by(AnalysisResult.created_at.desc())
-    results = session.exec(statement).all()
+    return _render_home(request, session, message="Analysis completed")
 
-    context = {
-        "request": request,
-        "default_prompt": DEFAULT_PROMPT,
-        "results": [
-            {
-                "id": result.id,
-                "image_filename": result.image_filename,
-                "prompt": result.prompt,
-                "caption": result.caption,
-                "unusual_summary": result.unusual_summary,
-                "detections": result.detections(),
-                "created_at": result.created_at,
-            }
-            for result in results
-        ],
-        "message": "Analysis completed",
-    }
-    return templates.TemplateResponse("index.html", context)
+
+@app.post("/scan-area", response_class=HTMLResponse)
+async def scan_area(
+    request: Request,
+    north: float = Form(...),
+    south: float = Form(...),
+    east: float = Form(...),
+    west: float = Form(...),
+    tile_size: float = Form(0.05),
+    prompt: str = Form(DEFAULT_PROMPT),
+    date: str | None = Form(None),
+    api_key: str | None = Form(None),
+    session: Session = Depends(get_session),
+):
+    analyzer = get_analyzer()
+    area_dir = AREA_SCAN_DIR / datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
+
+    selected_api_key = (api_key or "").strip() or NASA_API_KEY
+    requested_date = (date or "").strip() or None
+
+    try:
+        tiles, download_failures = await download_nasa_area_tiles(
+            north=north,
+            south=south,
+            east=east,
+            west=west,
+            dim=tile_size,
+            output_dir=area_dir,
+            api_key=selected_api_key,
+            date=requested_date,
+        )
+    except ValueError as exc:
+        if area_dir.exists():
+            try:
+                area_dir.rmdir()
+            except OSError:
+                shutil.rmtree(area_dir, ignore_errors=True)
+        return _render_home(request, session, message=str(exc))
+
+    if not tiles:
+        if area_dir.exists():
+            try:
+                next(area_dir.iterdir())
+            except StopIteration:
+                area_dir.rmdir()
+        base_message = "No imagery tiles were downloaded for the requested area."
+        if download_failures:
+            failures_count = len(download_failures)
+            failure_plural = "s" if failures_count != 1 else ""
+            base_message += f" {failures_count} NASA request{failure_plural} failed."
+        return _render_home(request, session, message=base_message)
+
+    processed_records: List[AnalysisResult] = []
+    analysis_failures: List[str] = []
+
+    for tile in tiles:
+        try:
+            analysis = analyzer.analyze(tile.path, prompt)
+        except Exception as exc:  # pragma: no cover - model failure
+            logger.exception(
+                "Analyzer failed for tile at lat %s lon %s: %s", tile.lat, tile.lon, exc
+            )
+            analysis_failures.append(f"{tile.lat:.4f}, {tile.lon:.4f}")
+            tile.path.unlink(missing_ok=True)
+            continue
+
+        record = AnalysisResult(
+            image_filename=str(tile.path.relative_to(UPLOAD_DIR)),
+            prompt=analysis["prompt"],
+            caption=analysis["caption"],
+            unusual_summary=analysis["unusual_summary"],
+            detection_payload=serialize_detections(analysis["detections"]),
+            created_at=datetime.utcnow(),
+        )
+        processed_records.append(record)
+
+    for record in processed_records:
+        session.add(record)
+    session.commit()
+
+    processed_count = len(processed_records)
+    if processed_count == 0 and area_dir.exists():
+        try:
+            next(area_dir.iterdir())
+        except StopIteration:
+            area_dir.rmdir()
+
+    summary_parts: List[str] = []
+    if processed_count:
+        processed_plural = "s" if processed_count != 1 else ""
+        summary_parts.append(f"Analyzed {processed_count} NASA tile{processed_plural}.")
+    download_failures_count = len(download_failures)
+    if download_failures_count:
+        download_plural = "s" if download_failures_count != 1 else ""
+        summary_parts.append(f"{download_failures_count} download{download_plural} failed.")
+    analysis_failures_count = len(analysis_failures)
+    if analysis_failures_count:
+        analysis_plural = "s" if analysis_failures_count != 1 else ""
+        summary_parts.append(
+            f"Failed to analyze {analysis_failures_count} tile{analysis_plural}."
+        )
+
+    message = " ".join(summary_parts) or "Area scan completed."
+    return _render_home(request, session, message=message)
 
 
 def _safe_filename(filename: str) -> str:
@@ -108,9 +184,39 @@ def _safe_filename(filename: str) -> str:
     return f"{safe_stem}_{timestamp}{suffix}"
 
 
-async def _save_upload(upload: UploadFile) -> Path:
+def _build_results(session: Session) -> List[Dict[str, object]]:
+    statement = select(AnalysisResult).order_by(AnalysisResult.created_at.desc())
+    results: List[AnalysisResult] = session.exec(statement).all()
+    return [
+        {
+            "id": result.id,
+            "image_filename": result.image_filename,
+            "prompt": result.prompt,
+            "caption": result.caption,
+            "unusual_summary": result.unusual_summary,
+            "detections": result.detections(),
+            "created_at": result.created_at,
+        }
+        for result in results
+    ]
+
+
+def _render_home(request: Request, session: Session, message: str | None = None):
+    context: Dict[str, object] = {
+        "request": request,
+        "default_prompt": DEFAULT_PROMPT,
+        "results": _build_results(session),
+    }
+    if message:
+        context["message"] = message
+    return templates.TemplateResponse("index.html", context)
+
+
+async def _save_upload(upload: UploadFile, *, target_dir: Path | None = None) -> Path:
+    destination = target_dir or UPLOAD_DIR
+    destination.mkdir(parents=True, exist_ok=True)
     filename = _safe_filename(upload.filename or "upload.png")
-    saved_path = UPLOAD_DIR / filename
+    saved_path = destination / filename
     with saved_path.open("wb") as buffer:
         shutil.copyfileobj(upload.file, buffer)
     return saved_path

--- a/app/services/imagery.py
+++ b/app/services/imagery.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+NASA_EARTH_IMAGERY_URL = "https://api.nasa.gov/planetary/earth/imagery"
+MIN_DIM = 0.01
+MAX_DIM = 0.5
+MAX_TILES_PER_RUN = 50
+REQUEST_TIMEOUT = httpx.Timeout(60.0)
+
+
+@dataclass
+class AreaTile:
+    """Metadata for a satellite tile downloaded from the NASA imagery API."""
+
+    lat: float
+    lon: float
+    path: Path
+    source_url: str
+
+
+async def download_nasa_area_tiles(
+    *,
+    north: float,
+    south: float,
+    east: float,
+    west: float,
+    dim: float,
+    output_dir: Path,
+    api_key: str,
+    date: str | None = None,
+) -> Tuple[List[AreaTile], List[str]]:
+    """Download a grid of imagery tiles that cover the requested bounding box.
+
+    Returns a tuple consisting of successfully downloaded tiles and a list of
+    human-readable error messages for tiles that could not be fetched.
+    """
+
+    _validate_bounds(north=north, south=south, east=east, west=west)
+    _validate_dim(dim)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    lat_centers = _build_axis_centers(
+        minimum=south,
+        maximum=north,
+        dim=dim,
+        clamp_min=-90.0 + dim / 2,
+        clamp_max=90.0 - dim / 2,
+    )
+    lon_centers = _build_axis_centers(
+        minimum=west,
+        maximum=east,
+        dim=dim,
+        clamp_min=-180.0 + dim / 2,
+        clamp_max=180.0 - dim / 2,
+    )
+
+    total_tiles = len(lat_centers) * len(lon_centers)
+    if total_tiles > MAX_TILES_PER_RUN:
+        raise ValueError(
+            "Requested area requires "
+            f"{total_tiles} tiles. Reduce coverage or increase the tile size to stay below "
+            f"the limit of {MAX_TILES_PER_RUN} requests per scan."
+        )
+
+    tiles: List[AreaTile] = []
+    failures: List[str] = []
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        for lat in lat_centers:
+            for lon in lon_centers:
+                params = {
+                    "lat": lat,
+                    "lon": lon,
+                    "dim": dim,
+                    "api_key": api_key,
+                }
+                if date:
+                    params["date"] = date
+
+                try:
+                    response = await client.get(NASA_EARTH_IMAGERY_URL, params=params)
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    detail = _short_error_detail(exc.response.text)
+                    failures.append(
+                        f"lat {lat:.4f}, lon {lon:.4f}: {exc.response.status_code} {detail}"
+                    )
+                    logger.warning(
+                        "NASA imagery request failed with status %s: %s",
+                        exc.response.status_code,
+                        detail,
+                    )
+                    continue
+                except httpx.RequestError as exc:
+                    failures.append(f"lat {lat:.4f}, lon {lon:.4f}: {exc}")
+                    logger.warning("NASA imagery request error: %s", exc)
+                    continue
+
+                filename = _tile_filename(lat, lon, date)
+                tile_path = output_dir / filename
+                tile_path.write_bytes(response.content)
+                tiles.append(
+                    AreaTile(
+                        lat=lat,
+                        lon=lon,
+                        path=tile_path,
+                        source_url=str(response.url),
+                    )
+                )
+
+    return tiles, failures
+
+
+def _validate_bounds(*, north: float, south: float, east: float, west: float) -> None:
+    if north <= south:
+        raise ValueError("North latitude must be greater than south latitude.")
+    if east <= west:
+        raise ValueError("East longitude must be greater than west longitude.")
+    if north > 90.0 or south < -90.0:
+        raise ValueError("Latitudes must be within -90 and 90 degrees.")
+    if east > 180.0 or west < -180.0:
+        raise ValueError("Longitudes must be within -180 and 180 degrees.")
+    if north - south > 180.0:
+        raise ValueError("Latitude span is too large for a single scan. Please reduce coverage.")
+    if east - west > 360.0:
+        raise ValueError("Longitude span cannot exceed 360 degrees.")
+
+
+def _validate_dim(dim: float) -> None:
+    if not (MIN_DIM <= dim <= MAX_DIM):
+        raise ValueError(
+            f"Tile size (dim) must be between {MIN_DIM} and {MAX_DIM} degrees as required by the NASA API."
+        )
+
+
+def _build_axis_centers(
+    *, minimum: float, maximum: float, dim: float, clamp_min: float, clamp_max: float
+) -> List[float]:
+    if maximum - minimum <= 0:
+        center = _clamp((maximum + minimum) / 2, clamp_min, clamp_max)
+        return [center]
+
+    tile_count = max(1, math.ceil((maximum - minimum) / dim))
+    centers: List[float] = []
+    for index in range(tile_count):
+        center = minimum + dim * (index + 0.5)
+        if center > maximum:
+            center = maximum - dim / 2
+        center = _clamp(center, clamp_min, clamp_max)
+        if centers and abs(center - centers[-1]) < 1e-6:
+            continue
+        centers.append(center)
+
+    if not centers:
+        centers.append(_clamp((maximum + minimum) / 2, clamp_min, clamp_max))
+
+    return centers
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(min(value, maximum), minimum)
+
+
+def _tile_filename(lat: float, lon: float, date: str | None) -> str:
+    lat_token = _sanitize_coord(lat)
+    lon_token = _sanitize_coord(lon)
+    if date:
+        date_token = date.replace("-", "")
+        return f"nasa_{date_token}_{lat_token}_{lon_token}.png"
+    return f"nasa_{lat_token}_{lon_token}.png"
+
+
+def _sanitize_coord(value: float) -> str:
+    token = f"{value:+.4f}".replace("+", "p").replace("-", "m").replace(".", "_")
+    return token
+
+
+def _short_error_detail(detail: str) -> str:
+    detail = detail.strip()
+    if len(detail) > 160:
+        return f"{detail[:157]}..."
+    return detail or "(no detail)"

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -20,7 +20,7 @@ h1 {
   margin-bottom: 0.25rem;
 }
 
-.upload form {
+.form-card {
   display: grid;
   gap: 1rem;
   padding: 1.5rem;
@@ -29,11 +29,27 @@ h1 {
   margin-bottom: 2.5rem;
 }
 
-.upload label {
+.form-card input,
+.form-card textarea {
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background-color: rgba(11, 18, 32, 0.7);
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.form-card input:focus,
+.form-card textarea:focus {
+  outline: 2px solid rgba(95, 137, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.form-card label {
   font-weight: 600;
 }
 
-.upload button {
+.form-card button {
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
   border: none;
@@ -44,8 +60,31 @@ h1 {
   transition: transform 0.2s ease;
 }
 
-.upload button:hover {
+.form-card button:hover {
   transform: translateY(-1px);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-card .hint {
+  font-size: 0.9rem;
+  opacity: 0.8;
+  margin: 0;
+}
+
+.area {
+  margin-bottom: 2.5rem;
 }
 
 .flash {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     <section class="upload">
-      <form action="/analyze" method="post" enctype="multipart/form-data">
+      <form class="form-card" action="/analyze" method="post" enctype="multipart/form-data">
         <label for="image">Satellite image</label>
         <input id="image" name="image" type="file" accept="image/*" required />
 
@@ -29,6 +29,97 @@
         <textarea id="prompt" name="prompt" rows="3">{{ default_prompt }}</textarea>
 
         <button type="submit">Analyze image</button>
+      </form>
+    </section>
+
+    <section class="area">
+      <h2>Automatic area scan</h2>
+      <p>
+        Request imagery for a latitude/longitude bounding box and the scanner will automatically
+        download tiles from the free NASA Earth imagery API before running the analysis pipeline on
+        each tile.
+      </p>
+      <form class="form-card" action="/scan-area" method="post">
+        <div class="form-grid">
+          <div class="field">
+            <label for="north">North latitude</label>
+            <input
+              id="north"
+              name="north"
+              type="number"
+              step="0.0001"
+              min="-90"
+              max="90"
+              required
+            />
+          </div>
+          <div class="field">
+            <label for="south">South latitude</label>
+            <input
+              id="south"
+              name="south"
+              type="number"
+              step="0.0001"
+              min="-90"
+              max="90"
+              required
+            />
+          </div>
+          <div class="field">
+            <label for="west">West longitude</label>
+            <input
+              id="west"
+              name="west"
+              type="number"
+              step="0.0001"
+              min="-180"
+              max="180"
+              required
+            />
+          </div>
+          <div class="field">
+            <label for="east">East longitude</label>
+            <input
+              id="east"
+              name="east"
+              type="number"
+              step="0.0001"
+              min="-180"
+              max="180"
+              required
+            />
+          </div>
+          <div class="field">
+            <label for="tile-size">Tile size (degrees)</label>
+            <input
+              id="tile-size"
+              name="tile_size"
+              type="number"
+              step="0.01"
+              min="0.01"
+              max="0.5"
+              value="0.05"
+              required
+            />
+          </div>
+          <div class="field">
+            <label for="date">Acquisition date (optional)</label>
+            <input id="date" name="date" type="date" />
+          </div>
+          <div class="field">
+            <label for="api-key">NASA API key (optional)</label>
+            <input id="api-key" name="api_key" type="text" placeholder="Defaults to DEMO_KEY" />
+          </div>
+        </div>
+        <p class="hint">
+          Large areas may require increasing the tile size to stay under the public NASA DEMO_KEY
+          rate limits. Provide your own API key for higher throughput.
+        </p>
+
+        <label for="area-prompt">Analysis prompt</label>
+        <textarea id="area-prompt" name="prompt" rows="3">{{ default_prompt }}</textarea>
+
+        <button type="submit">Scan area</button>
       </form>
     </section>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "sqlmodel>=0.0.14",
     "jinja2>=3.1.3",
     "python-multipart>=0.0.9",
+    "httpx>=0.26.0",
     "pillow>=9.5.0",
     "transformers>=4.37.2",
     "torch>=2.1.0",


### PR DESCRIPTION
## Summary
- replace the ZIP-based batch ingestion with a NASA Earth imagery downloader that analyzes bounding boxes automatically
- add an imagery service using httpx plus a new area scan route and UI for selecting coordinates, tile size, and API key
- refresh documentation and styling to describe the NASA-backed workflow and optional higher-rate API keys

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd71d020b08327a1e6654087ecec54