### PR TITLE
Switch area scanning to NASA GIBS imagery

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Key features:
 - **General object detection** powered by a DETR model capable of identifying a broad range of
   infrastructure and equipment beyond a fixed list of examples.
 - **Persistent storage** of every analysis run, including references to uploaded imagery.
-- **Automatic area scanning** by fetching NASA Earth imagery tiles for a bounding box and analyzing
+- **Automatic area scanning** by fetching NASA GIBS imagery tiles for a bounding box and analyzing
   them without preparing archives.
 
 ## Getting started
@@ -43,12 +43,9 @@ Key features:
 
 4. Open <http://localhost:8000> in your browser. You can either upload a single satellite image or
    use the automatic area scan form to request imagery for a latitude/longitude bounding box. The
-   app downloads tiles from the free NASA Earth imagery API, analyzes each tile, and stores the
-   results so you can revisit previous detections.
-
-   The application defaults to the public `DEMO_KEY`, which is limited to roughly 30 requests per
-   hour and a maximum of two imagery tiles per scan. Add your own NASA API key via the form for
-   higher throughput or larger areas.
+   app downloads tiles from NASA's Global Imagery Browse Services (GIBS), analyzes each tile, and
+   stores the results so you can revisit previous detections. Each scan is limited to 50 GIBS
+   requests to prevent accidental overload of the service.
 
 Uploaded imagery is stored under `data/uploads`, and analysis metadata is tracked in the
 `data/satellite_scans.db` SQLite database.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,8 +36,8 @@
       <h2>Automatic area scan</h2>
       <p>
         Request imagery for a latitude/longitude bounding box and the scanner will automatically
-        download tiles from the free NASA Earth imagery API before running the analysis pipeline on
-        each tile.
+        download tiles from NASA's Global Imagery Browse Services (GIBS) before running the analysis
+        pipeline on each tile.
       </p>
       <form class="form-card" action="/scan-area" method="post">
         <div class="form-grid">
@@ -115,14 +115,10 @@
               {% if default_date %}value="{{ default_date }}"{% endif %}
             />
           </div>
-          <div class="field">
-            <label for="api-key">NASA API key (optional)</label>
-            <input id="api-key" name="api_key" type="text" placeholder="Defaults to DEMO_KEY" />
-          </div>
         </div>
         <p class="hint">
-          Large areas may require increasing the tile size to stay under the public NASA DEMO_KEY
-          rate limits. Provide your own API key for higher throughput.
+          Large areas may require increasing the tile size to stay under the built-in limit of 50
+          GIBS requests per scan.
         </p>
 
         <label for="area-prompt">Analysis prompt</label>


### PR DESCRIPTION
## Summary
- replace the legacy NASA Earth imagery endpoint with NASA GIBS WMS tile requests and add payload validation
- update the FastAPI scan workflow and UI copy to reflect the new GIBS integration and remove the unused API key field
- refresh the README with instructions for the GIBS-based scanner and its request limits

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd7fe730488327a121af1bea2c1ddc