### PR TITLE
Increase GIBS tile resolution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -164,9 +164,12 @@ async def scan_area(
             area_dir.rmdir()
 
     summary_parts: List[str] = []
+    tile_resolution = tiles[0].pixel_size if tiles else None
     if processed_count:
         processed_plural = "s" if processed_count != 1 else ""
         summary_parts.append(f"Analyzed {processed_count} GIBS tile{processed_plural}.")
+    if tile_resolution:
+        summary_parts.append(f"Tile resolution: {tile_resolution}px.")
     download_failures_count = len(download_failures)
     if download_failures_count:
         download_plural = "s" if download_failures_count != 1 else ""

--- a/app/services/imagery.py
+++ b/app/services/imagery.py
@@ -16,8 +16,8 @@ GIBS_WMS_URL = "https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi"
 GIBS_DEFAULT_LAYER = "VIIRS_SNPP_CorrectedReflectance_TrueColor"
 GIBS_IMAGE_FORMAT = "image/png"
 GIBS_PIXELS_PER_DEGREE = 4096
-GIBS_MIN_TILE_PIXELS = 1024
-GIBS_MAX_TILE_PIXELS = 2048
+GIBS_MIN_TILE_PIXELS = 2048
+GIBS_MAX_TILE_PIXELS = 4096
 GIBS_DEFAULT_TIME = "default"
 
 RECENT_LOOKBACK_DAYS = 1
@@ -45,6 +45,7 @@ class AreaTile:
     lon: float
     path: Path
     source_url: str
+    pixel_size: int
 
 
 async def download_gibs_area_tiles(
@@ -160,6 +161,7 @@ async def download_gibs_area_tiles(
                         lon=lon,
                         path=tile_path,
                         source_url=str(response.url),
+                        pixel_size=tile_pixels,
                     )
                 )
 


### PR DESCRIPTION
## Summary
- request higher-resolution NASA GIBS imagery by raising the minimum tile size to 2048px and allowing up to 4096px
- capture each tile's pixel dimension and surface it in the area-scan summary so analysts can verify resolution

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd8e5e1cc883279a36f82bda58e25c