### PR TITLE
Add high-resolution Landsat fallback for GIBS tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Key features:
    stores the results so you can revisit previous detections. Each scan is limited to 50 GIBS
    requests to prevent accidental overload of the service, and every tile is requested at a minimum
    of 256×256 pixels so the vision models have enough detail to work with even for small bounding
-   boxes.
+   boxes. When the default VIIRS true-color layer is too blocky for object recognition, the
+   downloader automatically retries with the higher resolution Landsat WELD mosaic to deliver
+   ~30 m/pixel imagery.
 
 Uploaded imagery is stored under `data/uploads`, and analysis metadata is tracked in the
 `data/satellite_scans.db` SQLite database.


### PR DESCRIPTION
## Summary
- define configurable GIBS layer metadata and add a Landsat WELD fallback when VIIRS tiles are too blocky
- compute per-tile detail ratios and expose imagery metadata so the scan summary can report layer, native span, and approximate resolution
- document the automatic high-resolution retry in the README

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd9dbaf2848327a16742605210d460