### PR TITLE
Add aerial imagery provider selection for area scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Key features:
 - **General object detection** powered by a DETR model capable of identifying a broad range of
   infrastructure and equipment beyond a fixed list of examples.
 - **Persistent storage** of every analysis run, including references to uploaded imagery.
-- **Automatic area scanning** by fetching NASA GIBS imagery tiles for a bounding box and analyzing
-  them without preparing archives.
+- **Automatic area scanning** by fetching imagery for a bounding box from NASA GIBS or, when higher
+  detail is required, USGS NAIP aerial photography, analyzing each tile without preparing archives.
 
 ## Getting started
 
@@ -43,9 +43,10 @@ Key features:
 
 4. Open <http://localhost:8000> in your browser. You can either upload a single satellite image or
    use the automatic area scan form to request imagery for a latitude/longitude bounding box. The
-   app downloads tiles from NASA's Global Imagery Browse Services (GIBS), analyzes each tile, and
-   stores the results so you can revisit previous detections. Each scan is limited to 50 GIBS
-   requests to prevent accidental overload of the service, and every tile is requested at a minimum
+   app downloads tiles from your selected provider—NASA's Global Imagery Browse Services (GIBS) by
+   default, or USGS NAIP aerial mosaics when you need sub-meter detail—analyzes each tile, and
+   stores the results so you can revisit previous detections. Each scan is limited to 50 imagery
+   requests to prevent accidental overload of the services, and every tile is requested at a minimum
    of 256×256 pixels so the vision models have enough detail to work with even for small bounding
    boxes. When the default VIIRS true-color layer is too blocky for object recognition, the
    downloader automatically retries with the higher resolution Landsat WELD mosaic to deliver

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,8 +36,9 @@
       <h2>Automatic area scan</h2>
       <p>
         Request imagery for a latitude/longitude bounding box and the scanner will automatically
-        download tiles from NASA's Global Imagery Browse Services (GIBS) before running the analysis
-        pipeline on each tile.
+        download tiles from the selected provider before running the analysis pipeline on each tile.
+        NASA's Global Imagery Browse Services (GIBS) offers worldwide coverage, while the USGS NAIP
+        option delivers sub-meter aerial photography across the continental United States.
       </p>
       <form class="form-card" action="/scan-area" method="post">
         <div class="form-grid">
@@ -107,6 +108,21 @@
             />
           </div>
           <div class="field">
+            <label for="provider">Imagery source</label>
+            <select id="provider" name="provider">
+              {% for option in providers %}
+              <option
+                value="{{ option.key }}"
+                title="{{ option.description }}"
+                {% if option.key == selected_provider %}selected{% endif %}
+              >
+                {{ option.label }}
+              </option>
+              {% endfor %}
+            </select>
+            <p class="hint">Hover the options for coverage and resolution details.</p>
+          </div>
+          <div class="field">
             <label for="date">Acquisition date (optional)</label>
             <input
               id="date"
@@ -118,7 +134,7 @@
         </div>
         <p class="hint">
           Large areas may require increasing the tile size to stay under the built-in limit of 50
-          GIBS requests per scan.
+          imagery requests per scan.
         </p>
 
         <label for="area-prompt">Analysis prompt</label>


### PR DESCRIPTION
## Summary
- add an imagery provider registry with USGS NAIP aerial tiles alongside NASA GIBS
- extend the area scan flow to let users choose a provider, persist the selection, and surface provider-aware messaging
- document the new provider options in the UI and README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda62a3d4c8327b1b1f9a4ddc2550e