### PR TITLE
Handle NAIP WMS axis quirks

### DIFF
--- a/app/services/imagery.py
+++ b/app/services/imagery.py
@@ -340,9 +340,17 @@ async def download_naip_area_tiles(
                 }
 
                 request_attempts = [
-                    ("1.3.0", "CRS", bbox_lon_lat, "lon-lat"),
+                    # WMS 1.3.0 swaps the axis order for EPSG:4326 compared to the legacy
+                    # specification, however some ArcGIS deployments still honour the older
+                    # behaviour. Try the standards-compliant latitude/longitude order first,
+                    # then fall back to the alternate ordering before attempting version 1.1.1.
                     ("1.3.0", "CRS", bbox_lat_lon, "lat-lon"),
+                    ("1.3.0", "CRS", bbox_lon_lat, "lon-lat"),
+                    # A number of NAIP endpoints erroneously expect latitude/longitude even
+                    # when negotiating WMS 1.1.1 responses. Include both permutations so the
+                    # downloader can gracefully recover instead of failing with a 400 error.
                     ("1.1.1", "SRS", bbox_lon_lat, "lon-lat"),
+                    ("1.1.1", "SRS", bbox_lat_lon, "lat-lon"),
                 ]
 
                 response: httpx.Response | None = None


### PR DESCRIPTION
## Summary
- adjust the NAIP WMS request sequence to try both axis orders for versions 1.3.0 and 1.1.1
- add context explaining why alternate latitude/longitude permutations are attempted when contacting ArcGIS endpoints

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cdb5519d548327a24f3e605e5aefb1