### PR TITLE
Ensure MapTiler requests retain attribution overlay

### DIFF
--- a/app/services/imagery.py
+++ b/app/services/imagery.py
@@ -281,9 +281,12 @@ async def download_maptiler_area_tiles(
                 )
 
                 try:
+                    # Free MapTiler plans require the attribution overlay to remain enabled,
+                    # otherwise the API responds with an HTTP 403 image payload.
+                    params = {"key": api_key, "attribution": "true"}
                     response = await client.get(
                         url,
-                        params={"key": api_key, "attribution": "false"},
+                        params=params,
                     )
                     response.raise_for_status()
                 except httpx.HTTPStatusError as exc:


### PR DESCRIPTION
## Summary
- keep the MapTiler static imagery attribution overlay enabled so free-tier keys are accepted
- add an inline note explaining the HTTP 403 error behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce56e420e8832796aeadd19f6bfa3a