### PR TITLE
Guard MapTiler downloads near latitude limit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_maptiler_latitude.py
+++ b/tests/test_maptiler_latitude.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from app.services.imagery import MAPTILER_LATITUDE_LIMIT, download_maptiler_area_tiles
+
+
+def test_maptiler_rejects_out_of_range_latitudes(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAPTILER_API_KEY", "test-key")
+
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(
+            download_maptiler_area_tiles(
+                north=MAPTILER_LATITUDE_LIMIT + 1.0,
+                south=MAPTILER_LATITUDE_LIMIT - 0.5,
+                east=10.0,
+                west=9.0,
+                dim=0.1,
+                output_dir=tmp_path,
+            )
+        )
+
+    message = str(exc.value)
+    assert "latitude" in message.lower()
+    assert "gibs" in message.lower()


### PR DESCRIPTION
## Summary
- clamp MapTiler scan requests to the provider's supported latitude range and surface a helpful error when the bounds exceed it
- add a regression test covering the latitude guard and ensure the test suite can import the application package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce5b63ce30832789859b0dccb145de