### PR TITLE
Switch captioning pipeline to BLIP-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ system stores detected objects and metadata in a SQLite database for later revie
 
 Key features:
 
-- **Image captioning** using BLIP to summarize the context of the uploaded scene.
+- **Image captioning** using BLIP-2 to summarize the context of the uploaded scene.
 - **Promptable visual question answering** to respond to analyst questions such as the default
   "Describe all unusual objects in this image".
 - **General object detection** powered by a DETR model capable of identifying a broad range of
@@ -33,7 +33,7 @@ Key features:
    pip install -e .
    ```
 
-   The first run will download the required Hugging Face models (BLIP for captioning and VILT for
+   The first run will download the required Hugging Face models (BLIP-2 for captioning and VILT for
    visual question answering). Expect this to take a few minutes.
 
 3. Configure your MapTiler API key (required for the default imagery provider):

--- a/app/services/analyzer.py
+++ b/app/services/analyzer.py
@@ -23,7 +23,7 @@ class SatelliteAnalyzer:
     def __init__(self) -> None:
         logger.info("Loading captioning and VQA pipelines for satellite analysis")
         self.captioning = pipeline(
-            "image-to-text", model="Salesforce/blip-image-captioning-base"
+            "image-to-text", model="Salesforce/blip2-flan-t5-xl"
         )
         self.vqa = pipeline(
             "visual-question-answering", model="dandelin/vilt-b32-finetuned-vqa"


### PR DESCRIPTION
## Summary
- swap the image captioning pipeline to Salesforce's BLIP-2 FLAN-T5 XL model
- update documentation to reflect the new captioning model

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce65c9cfd083279f34fb255a37c935