### PR TITLE
Add imagery caching, API usage tracking, and global scan support

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -25,3 +25,9 @@ class AnalysisResult(SQLModel, table=True):
     def detection_labels(self) -> str:
         detected = [item.get("object") for item in self.detections() if item.get("object")]
         return ", ".join(detected)
+
+
+class ApiUsageStat(SQLModel, table=True):
+    provider: str = Field(primary_key=True)
+    request_count: int = Field(default=0)
+    last_used_at: datetime | None = Field(default=None, nullable=True)

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+
+
+class TileCache:
+    """Simple on-disk cache for storing downloaded imagery tiles."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def load(self, key: str, extension: str, destination: Path) -> Dict[str, Any] | None:
+        """Copy a cached tile to ``destination`` and return its metadata."""
+
+        cache_path = self._path(key, extension, ensure_parent=False)
+        if not cache_path.exists():
+            return None
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(cache_path, destination)
+        return self._read_metadata(cache_path)
+
+    def store(self, key: str, extension: str, content: bytes, metadata: Dict[str, Any]) -> Path:
+        """Persist ``content`` and ``metadata`` under the provided cache ``key``."""
+
+        cache_path = self._path(key, extension, ensure_parent=True)
+        cache_path.write_bytes(content)
+        self._write_metadata(cache_path, metadata)
+        return cache_path
+
+    def _path(self, key: str, extension: str, *, ensure_parent: bool) -> Path:
+        digest = hashlib.sha1(key.encode("utf-8")).hexdigest()
+        directory = self.root / digest[:2] / digest[2:4]
+        if ensure_parent:
+            directory.mkdir(parents=True, exist_ok=True)
+        extension = self._normalize_extension(extension)
+        return directory / f"{digest}{extension}"
+
+    def _metadata_path(self, cache_path: Path) -> Path:
+        return cache_path.parent / f"{cache_path.name}.json"
+
+    def _read_metadata(self, cache_path: Path) -> Dict[str, Any]:
+        metadata_path = self._metadata_path(cache_path)
+        if not metadata_path.exists():
+            return {}
+        try:
+            return json.loads(metadata_path.read_text())
+        except json.JSONDecodeError:
+            return {}
+
+    def _write_metadata(self, cache_path: Path, metadata: Dict[str, Any]) -> None:
+        metadata_path = self._metadata_path(cache_path)
+        metadata_path.write_text(json.dumps(metadata, sort_keys=True))
+
+    @staticmethod
+    def _normalize_extension(extension: str) -> str:
+        return extension if extension.startswith(".") else f".{extension}"

--- a/app/services/usage.py
+++ b/app/services/usage.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlmodel import select
+
+from ..database import init_db, session_scope
+from ..models import ApiUsageStat
+
+
+_usage_initialized = False
+
+
+def _ensure_usage_table() -> None:
+    global _usage_initialized
+    if not _usage_initialized:
+        init_db()
+        _usage_initialized = True
+
+
+def record_api_usage(provider: str, *, increment: int = 1) -> None:
+    """Increment the API usage counter for the given provider."""
+
+    if increment <= 0:
+        return
+
+    _ensure_usage_table()
+
+    with session_scope() as session:
+        statement = select(ApiUsageStat).where(ApiUsageStat.provider == provider)
+        usage = session.exec(statement).one_or_none()
+        now = datetime.now(UTC)
+        if usage is None:
+            usage = ApiUsageStat(provider=provider, request_count=increment, last_used_at=now)
+            session.add(usage)
+        else:
+            usage.request_count += increment
+            usage.last_used_at = now
+        session.commit()

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -64,6 +64,24 @@ h1 {
   transform: translateY(-1px);
 }
 
+.form-card .secondary-button {
+  background: transparent;
+  border: 1px solid rgba(95, 137, 255, 0.6);
+  color: inherit;
+}
+
+.form-card .secondary-button:hover {
+  background-color: rgba(95, 137, 255, 0.12);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
 .form-grid {
   display: grid;
   gap: 1rem;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -101,8 +101,8 @@
               name="tile_size"
               type="number"
               step="0.01"
-              min="0.01"
-              max="0.5"
+              min="{{ '%.2f'|format(min_tile_size) }}"
+              max="{{ '%.2f'|format(max_tile_size) }}"
               value="{{ '%.2f'|format(default_tile_size) }}"
               required
             />
@@ -132,6 +132,14 @@
             />
           </div>
         </div>
+        <div class="form-actions">
+          <button type="button" id="global-scan" class="secondary-button">
+            Use worldwide coverage
+          </button>
+          <span class="hint">
+            Prefills the form with global bounds and the largest supported tile size.
+          </span>
+        </div>
         <p class="hint">
           Large areas may require increasing the tile size to stay under the built-in limit of 50
           imagery requests per scan.
@@ -142,6 +150,38 @@
 
         <button type="submit">Scan area</button>
       </form>
+    </section>
+
+    <section class="usage results">
+      <h2>API usage</h2>
+      {% if api_usage %}
+      <table>
+        <thead>
+          <tr>
+            <th>Provider</th>
+            <th>Requests</th>
+            <th>Last used</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in api_usage %}
+          <tr>
+            <td>{{ entry.provider_label }}</td>
+            <td>{{ entry.request_count }}</td>
+            <td>
+              {% if entry.last_used_at %}
+              {{ entry.last_used_at.strftime('%Y-%m-%d %H:%M:%S') }}
+              {% else %}
+              &mdash;
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p>No API requests have been recorded yet.</p>
+      {% endif %}
     </section>
 
     <section class="results">
@@ -201,5 +241,23 @@
       <p>No analyses have been recorded yet. Upload your first satellite scene to begin.</p>
       {% endif %}
     </section>
+    <script>
+      (function () {
+        const button = document.getElementById("global-scan");
+        if (!button) return;
+        button.addEventListener("click", function () {
+          const north = document.getElementById("north");
+          const south = document.getElementById("south");
+          const east = document.getElementById("east");
+          const west = document.getElementById("west");
+          const tile = document.getElementById("tile-size");
+          if (north) north.value = "90";
+          if (south) south.value = "-90";
+          if (east) east.value = "180";
+          if (west) west.value = "-180";
+          if (tile) tile.value = "{{ '%.2f'|format(max_tile_size) }}";
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a filesystem-backed tile cache and configurable request delay to throttle imagery downloads while avoiding duplicate API calls
- track per-provider API usage in the database and surface the counts plus a worldwide coverage shortcut in the UI alongside support for 360° scans
- extend tests to cover the new caching behaviour and ensure MapTiler requests honour the cache and configuration overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce6c60373c8327b64d908497b562ea