### PR TITLE
Enhance area scan UI with map selection and thumbnails

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -43,8 +43,8 @@ DEFAULT_SCAN_BOUNDS = {
     "west": 16.3588,
     "east": 16.3888,
 }
-# A 0.03° tile size provides a single high-resolution tile for the Vienna default area.
-DEFAULT_SCAN_TILE_SIZE = 0.03
+# A 0.01° tile size keeps the default Vienna area focused while providing more detail by default.
+DEFAULT_SCAN_TILE_SIZE = 0.01
 DEFAULT_SCAN_DATE: str | None = None
 DEFAULT_IMAGERY_PROVIDER = ImageryProviderKey.MAPTILER_SATELLITE
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -29,6 +29,72 @@ h1 {
   margin-bottom: 2.5rem;
 }
 
+.upload-toggle {
+  display: block;
+  border-radius: 12px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 2.5rem;
+  overflow: hidden;
+}
+
+.upload-toggle summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 1.1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.upload-toggle summary:hover {
+  background-color: rgba(95, 137, 255, 0.12);
+}
+
+.upload-toggle[open] summary {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.upload-toggle summary::-webkit-details-marker {
+  display: none;
+}
+
+.upload-toggle summary::after {
+  content: "▸";
+  font-size: 1.1rem;
+  opacity: 0.75;
+  transition: transform 0.2s ease;
+}
+
+.upload-toggle[open] summary::after {
+  transform: rotate(90deg);
+}
+
+.summary-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.summary-title {
+  font-size: 1.05rem;
+}
+
+.summary-description {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.upload-toggle .form-card {
+  margin: 0;
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 0.04);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
 .form-card input,
 .form-card textarea {
   padding: 0.75rem;
@@ -104,6 +170,57 @@ h1 {
   gap: 0.5rem;
 }
 
+.field-full {
+  grid-column: 1 / -1;
+}
+
+.field-label {
+  font-weight: 600;
+}
+
+.map-field {
+  gap: 0.75rem;
+}
+
+.scan-map {
+  height: 320px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+}
+
+.scan-map .leaflet-control-container .leaflet-control {
+  background-color: rgba(11, 18, 32, 0.85);
+  color: #e6edf7;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.scan-map .leaflet-bar a {
+  color: inherit;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.scan-map .leaflet-bar a:last-child {
+  border-bottom: none;
+}
+
+.scan-map .leaflet-bar a:hover {
+  background-color: rgba(95, 137, 255, 0.2);
+}
+
+.leaflet-marker-icon.map-handle {
+  background: linear-gradient(135deg, #5f89ff, #a855f7);
+  border: 2px solid rgba(11, 18, 32, 0.8);
+  border-radius: 6px;
+  box-shadow: 0 0 0 2px rgba(95, 137, 255, 0.3);
+  cursor: grab;
+}
+
+.leaflet-marker-icon.map-handle.leaflet-dragging,
+.leaflet-marker-icon.map-handle:active {
+  cursor: grabbing;
+}
+
 .form-card .hint {
   font-size: 0.9rem;
   opacity: 0.8;
@@ -138,6 +255,46 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.scan-gallery {
+  display: none;
+  margin-top: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  background-color: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+}
+
+.scan-gallery.visible {
+  display: block;
+}
+
+.thumbnail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.scan-thumbnail {
+  display: block;
+  overflow: hidden;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background-color: rgba(11, 18, 32, 0.7);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+.scan-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.scan-thumbnail:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
 }
 
 .scan-events li {
@@ -219,6 +376,34 @@ h1 {
 
 .results li {
   margin-bottom: 0.75rem;
+}
+
+.image-cell .image-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.image-cell .image-link span {
+  word-break: break-word;
+}
+
+.image-cell .image-link:focus {
+  outline: 2px solid rgba(95, 137, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.tile-thumbnail {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  background-color: rgba(11, 18, 32, 0.6);
+  flex-shrink: 0;
 }
 
 .results .meta {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Satellite Infrastructure Scanner</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
@@ -21,15 +25,26 @@
     {% endif %}
 
     <section class="upload">
-      <form class="form-card" action="/analyze" method="post" enctype="multipart/form-data">
-        <label for="image">Satellite image</label>
-        <input id="image" name="image" type="file" accept="image/*" required />
+      <details class="upload-toggle">
+        <summary>
+          <div class="summary-content">
+            <span class="summary-title">Analyze a single image</span>
+            <span class="summary-description"
+              >Upload an individual scene when you don't need a full area
+              scan.</span
+            >
+          </div>
+        </summary>
+        <form class="form-card" action="/analyze" method="post" enctype="multipart/form-data">
+          <label for="image">Satellite image</label>
+          <input id="image" name="image" type="file" accept="image/*" required />
 
-        <label for="prompt">Analysis prompt</label>
-        <textarea id="prompt" name="prompt" rows="3">{{ default_prompt }}</textarea>
+          <label for="prompt">Analysis prompt</label>
+          <textarea id="prompt" name="prompt" rows="3">{{ default_prompt }}</textarea>
 
-        <button type="submit">Analyze image</button>
-      </form>
+          <button type="submit">Analyze image</button>
+        </form>
+      </details>
     </section>
 
     <section class="area">
@@ -93,6 +108,14 @@
               value="{{ '%.4f'|format(default_bounds.east) }}"
               required
             />
+          </div>
+          <div class="field field-full map-field">
+            <span class="field-label">Select scan area</span>
+            <div id="scan-map" class="scan-map" aria-describedby="map-hint"></div>
+            <p class="hint" id="map-hint">
+              Drag the corner handles to adjust the bounding box or edit the
+              coordinates directly.
+            </p>
           </div>
           <div class="field">
             <label for="tile-size">Tile size (degrees)</label>
@@ -160,6 +183,13 @@
         <p class="hint">Updates appear as each tile is downloaded and analyzed.</p>
         <ul id="scan-events" class="scan-events"></ul>
       </div>
+      <div class="scan-gallery" id="scan-gallery">
+        <h3>Scanned tile thumbnails</h3>
+        <p class="hint">
+          Preview the most recent imagery tiles analyzed during the current scan.
+        </p>
+        <div class="thumbnail-grid" id="scan-thumbnails"></div>
+      </div>
     </section>
 
     <section class="usage results">
@@ -211,10 +241,22 @@
           {% for result in results %}
           <tr>
             <td>{{ result.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-            <td>
-              <a href="/data/uploads/{{ result.image_filename }}" target="_blank">
-                {{ result.image_filename }}
+            <td class="image-cell">
+              {% if result.image_filename %}
+              {% set image_url = '/data/uploads/' ~ result.image_filename %}
+              {% set image_label = result.image_filename.rsplit('/', 1)[-1] %}
+              <a href="{{ image_url }}" target="_blank" class="image-link">
+                <img
+                  src="{{ image_url }}"
+                  alt="{{ image_label }}"
+                  class="tile-thumbnail"
+                  loading="lazy"
+                />
+                <span>{{ image_label }}</span>
               </a>
+              {% else %}
+              <em>No image available</em>
+              {% endif %}
             </td>
             <td>{{ result.caption }}</td>
             <td>{{ result.unusual_summary }}</td>
@@ -251,6 +293,7 @@
       <p>No analyses have been recorded yet. Upload your first satellite scene to begin.</p>
       {% endif %}
     </section>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
       (function () {
         const form = document.getElementById("area-scan-form");
@@ -260,9 +303,44 @@
         const eventsList = document.getElementById("scan-events");
         const progressSection = document.getElementById("scan-progress");
         const historyTable = document.querySelector(".results table tbody");
+        const gallerySection = document.getElementById("scan-gallery");
+        const thumbnailGrid = document.getElementById("scan-thumbnails");
+        const boundsInputs = {
+          north: document.getElementById("north"),
+          south: document.getElementById("south"),
+          east: document.getElementById("east"),
+          west: document.getElementById("west"),
+        };
+
+        let refreshBoundsFromInputs = () => {};
         let eventSource = null;
         let activeScanId = null;
         let tileCounter = 0;
+
+        function getBoundsFromInputs() {
+          if (!window.L || typeof window.L.latLngBounds !== "function") {
+            return null;
+          }
+          const north = boundsInputs.north ? parseFloat(boundsInputs.north.value) : NaN;
+          const south = boundsInputs.south ? parseFloat(boundsInputs.south.value) : NaN;
+          const east = boundsInputs.east ? parseFloat(boundsInputs.east.value) : NaN;
+          const west = boundsInputs.west ? parseFloat(boundsInputs.west.value) : NaN;
+          if ([north, south, east, west].some((value) => Number.isNaN(value))) {
+            return null;
+          }
+          const normalizedNorth = Math.max(north, south);
+          const normalizedSouth = Math.min(north, south);
+          const normalizedEast = Math.max(east, west);
+          const normalizedWest = Math.min(east, west);
+          return L.latLngBounds(
+            [
+              [normalizedSouth, normalizedWest],
+              [normalizedNorth, normalizedEast],
+            ]
+          );
+        }
+
+        initializeMap();
 
         function safeParse(data) {
           try {
@@ -279,6 +357,12 @@
           }
           if (progressSection) {
             progressSection.classList.remove("visible");
+          }
+          if (thumbnailGrid) {
+            thumbnailGrid.innerHTML = "";
+          }
+          if (gallerySection) {
+            gallerySection.classList.remove("visible");
           }
         }
 
@@ -300,6 +384,38 @@
           eventsList.prepend(item);
           if (progressSection) {
             progressSection.classList.add("visible");
+          }
+        }
+
+        function getFileNameFromPath(path) {
+          if (typeof path !== "string") return "";
+          const parts = path.split("/").filter(Boolean);
+          return parts.length ? parts[parts.length - 1] : path;
+        }
+
+        function addThumbnail(tile) {
+          if (!thumbnailGrid || !tile || !tile.image) {
+            return;
+          }
+          const link = document.createElement("a");
+          link.href = tile.image;
+          link.target = "_blank";
+          link.className = "scan-thumbnail";
+
+          const img = document.createElement("img");
+          img.src = tile.image;
+          img.alt = tile.caption || getFileNameFromPath(tile.image) || "Tile";
+          img.loading = "lazy";
+
+          link.appendChild(img);
+          thumbnailGrid.prepend(link);
+
+          while (thumbnailGrid.childElementCount > 12) {
+            thumbnailGrid.removeChild(thumbnailGrid.lastElementChild);
+          }
+
+          if (gallerySection) {
+            gallerySection.classList.add("visible");
           }
         }
 
@@ -328,11 +444,24 @@
           row.appendChild(timestampCell);
 
           const imageCell = document.createElement("td");
+          imageCell.className = "image-cell";
           if (tile.image) {
             const link = document.createElement("a");
             link.href = tile.image;
             link.target = "_blank";
-            link.textContent = tile.image.split("/").pop() || "Tile";
+            link.className = "image-link";
+
+            const thumbnail = document.createElement("img");
+            thumbnail.src = tile.image;
+            thumbnail.alt = getFileNameFromPath(tile.image) || "Tile";
+            thumbnail.className = "tile-thumbnail";
+            thumbnail.loading = "lazy";
+
+            const label = document.createElement("span");
+            label.textContent = getFileNameFromPath(tile.image) || "Tile";
+
+            link.appendChild(thumbnail);
+            link.appendChild(label);
             imageCell.appendChild(link);
           } else {
             imageCell.textContent = "Tile";
@@ -387,6 +516,9 @@
             if (east) east.value = "180";
             if (west) west.value = "-180";
             if (tile) tile.value = "{{ '%.2f'|format(max_tile_size) }}";
+            if (typeof refreshBoundsFromInputs === "function") {
+              refreshBoundsFromInputs();
+            }
           });
         }
 
@@ -404,9 +536,9 @@
             });
 
             activeScanId =
-              (window.crypto && typeof window.crypto.randomUUID === "function"
+              window.crypto && typeof window.crypto.randomUUID === "function"
                 ? window.crypto.randomUUID()
-                : `scan-${Date.now()}`);
+                : `scan-${Date.now()}`;
             params.append("scan_id", activeScanId);
 
             const url = `/scan-area/stream?${params.toString()}`;
@@ -432,6 +564,7 @@
               const caption = payload.caption || "Tile analyzed.";
               appendEvent(`Tile #${index}: ${caption}`, "success");
               updateHistoryTable(payload);
+              addThumbnail(payload);
             });
 
             eventSource.addEventListener("download-failed", (evt) => {
@@ -493,6 +626,191 @@
             setRunning(false);
             closeSource();
           });
+        }
+
+        function initializeMap() {
+          const container = document.getElementById("scan-map");
+          if (!container || !window.L || typeof window.L.map !== "function") {
+            return;
+          }
+
+          const map = L.map(container, {
+            zoomControl: true,
+            attributionControl: true,
+          });
+
+          L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+            attribution: "© OpenStreetMap contributors",
+            maxZoom: 19,
+          }).addTo(map);
+
+          const rectangleOptions = {
+            color: "#5f89ff",
+            weight: 1.5,
+            fillOpacity: 0.08,
+          };
+
+          function boundsToObject(bounds) {
+            return {
+              north: bounds.getNorth(),
+              south: bounds.getSouth(),
+              east: bounds.getEast(),
+              west: bounds.getWest(),
+            };
+          }
+
+          function objectToLatLngBounds(boundsObject) {
+            return L.latLngBounds(
+              [
+                [boundsObject.south, boundsObject.west],
+                [boundsObject.north, boundsObject.east],
+              ]
+            );
+          }
+
+          const defaultBounds = getBoundsFromInputs();
+          let currentBounds = defaultBounds
+            ? boundsToObject(defaultBounds)
+            : { north: 10, south: -10, east: 10, west: -10 };
+
+          let rectangle = L.rectangle(
+            objectToLatLngBounds(currentBounds),
+            rectangleOptions
+          ).addTo(map);
+
+          const handleIcon = L.divIcon({
+            className: "map-handle",
+            iconSize: [16, 16],
+            iconAnchor: [8, 8],
+          });
+
+          const handles = {
+            northWest: L.marker(
+              [currentBounds.north, currentBounds.west],
+              { draggable: true, icon: handleIcon }
+            ),
+            northEast: L.marker(
+              [currentBounds.north, currentBounds.east],
+              { draggable: true, icon: handleIcon }
+            ),
+            southWest: L.marker(
+              [currentBounds.south, currentBounds.west],
+              { draggable: true, icon: handleIcon }
+            ),
+            southEast: L.marker(
+              [currentBounds.south, currentBounds.east],
+              { draggable: true, icon: handleIcon }
+            ),
+          };
+
+          Object.values(handles).forEach((marker) => marker.addTo(map));
+
+          function updateInputsFromBounds(boundsObject) {
+            const digits = 4;
+            if (boundsInputs.north) {
+              boundsInputs.north.value = boundsObject.north.toFixed(digits);
+            }
+            if (boundsInputs.south) {
+              boundsInputs.south.value = boundsObject.south.toFixed(digits);
+            }
+            if (boundsInputs.east) {
+              boundsInputs.east.value = boundsObject.east.toFixed(digits);
+            }
+            if (boundsInputs.west) {
+              boundsInputs.west.value = boundsObject.west.toFixed(digits);
+            }
+          }
+
+          function updateHandles(boundsObject) {
+            handles.northWest.setLatLng([boundsObject.north, boundsObject.west]);
+            handles.northEast.setLatLng([boundsObject.north, boundsObject.east]);
+            handles.southWest.setLatLng([boundsObject.south, boundsObject.west]);
+            handles.southEast.setLatLng([boundsObject.south, boundsObject.east]);
+          }
+
+          function syncFromBounds(boundsObject, options = {}) {
+            currentBounds = boundsObject;
+            rectangle.setBounds(objectToLatLngBounds(currentBounds));
+            updateHandles(currentBounds);
+            if (options.updateInputs !== false) {
+              updateInputsFromBounds(currentBounds);
+            }
+            if (options.fitMap) {
+              map.fitBounds(objectToLatLngBounds(currentBounds).pad(0.05));
+            }
+          }
+
+          const minLatSpan = 0.0001;
+          const minLngSpan = 0.0001;
+
+          function clamp(value, min, max) {
+            return Math.min(Math.max(value, min), max);
+          }
+
+          function handleDrag(corner) {
+            return function () {
+              const latLng = handles[corner].getLatLng();
+              const updated = { ...currentBounds };
+              if (corner === "northWest" || corner === "northEast") {
+                updated.north = clamp(
+                  latLng.lat,
+                  updated.south + minLatSpan,
+                  90
+                );
+              }
+              if (corner === "southWest" || corner === "southEast") {
+                updated.south = clamp(
+                  latLng.lat,
+                  -90,
+                  updated.north - minLatSpan
+                );
+              }
+              if (corner === "northWest" || corner === "southWest") {
+                updated.west = clamp(
+                  latLng.lng,
+                  -180,
+                  updated.east - minLngSpan
+                );
+              }
+              if (corner === "northEast" || corner === "southEast") {
+                updated.east = clamp(
+                  latLng.lng,
+                  updated.west + minLngSpan,
+                  180
+                );
+              }
+              syncFromBounds(updated, { fitMap: false });
+            };
+          }
+
+          function handleDragEnd() {
+            map.fitBounds(objectToLatLngBounds(currentBounds).pad(0.05));
+          }
+
+          handles.northWest.on("drag", handleDrag("northWest"));
+          handles.northWest.on("dragend", handleDragEnd);
+          handles.northEast.on("drag", handleDrag("northEast"));
+          handles.northEast.on("dragend", handleDragEnd);
+          handles.southWest.on("drag", handleDrag("southWest"));
+          handles.southWest.on("dragend", handleDragEnd);
+          handles.southEast.on("drag", handleDrag("southEast"));
+          handles.southEast.on("dragend", handleDragEnd);
+
+          refreshBoundsFromInputs = function () {
+            const bounds = getBoundsFromInputs();
+            if (!bounds) {
+              return;
+            }
+            syncFromBounds(boundsToObject(bounds), { fitMap: true });
+          };
+
+          Object.values(boundsInputs).forEach((input) => {
+            if (!input) return;
+            input.addEventListener("change", refreshBoundsFromInputs);
+            input.addEventListener("blur", refreshBoundsFromInputs);
+          });
+
+          syncFromBounds(currentBounds, { fitMap: true });
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- hide the single-image analyzer behind a collapsible card so the area scan tools stay in focus
- add a Leaflet-powered bounding-box selector and live thumbnail gallery for area scans
- lower the default scan tile size to 0.01 degrees for finer granularity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7a5692608327870a8ffe3fe99e56