### PR TITLE
Remove tile cap and throttle only remote imagery requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Key features:
    use the automatic area scan form to request imagery for a latitude/longitude bounding box. By
    default the app retrieves crisp MapTiler satellite imagery centered on Vienna, Austria, but you
    can switch to NASA's Global Imagery Browse Services (GIBS) or the USGS NAIP aerial mosaics when
-   you need alternate coverage. Each scan is limited to 50 imagery requests to prevent accidental
-   overload of the services, and every tile is requested at a minimum of 256×256 pixels so the
+   you need alternate coverage. The downloader reuses cached tiles immediately and only throttles
+   outbound web requests, and every tile is requested at a minimum of 256×256 pixels so the
    vision models have enough detail to work with even for small bounding boxes. When the NASA GIBS
    VIIRS true-color layer is too blocky for object recognition, the downloader automatically retries
    with the higher resolution Landsat WELD mosaic to deliver ~30 m/pixel imagery.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -164,8 +164,8 @@
           </span>
         </div>
         <p class="hint">
-          Large areas may require increasing the tile size to stay under the built-in limit of 50
-          imagery requests per scan.
+          Large areas may require increasing the tile size to keep the number of imagery requests
+          and download time manageable.
         </p>
 
         <label for="area-prompt">Analysis prompt</label>

--- a/tests/test_maptiler_requests.py
+++ b/tests/test_maptiler_requests.py
@@ -52,6 +52,7 @@ def test_maptiler_trims_api_key_and_uses_referer(tmp_path, monkeypatch):
     monkeypatch.setenv("IMAGERY_REQUEST_DELAY", "0")
     monkeypatch.setenv("IMAGERY_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr(imagery, "_tile_cache", None)
+    monkeypatch.setattr(imagery, "_last_remote_request_at", None)
     monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
 
     tiles, failures = asyncio.run(
@@ -121,6 +122,7 @@ def test_maptiler_reuses_cached_tiles(tmp_path, monkeypatch):
     monkeypatch.setenv("IMAGERY_REQUEST_DELAY", "0")
     monkeypatch.setenv("IMAGERY_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr(imagery, "_tile_cache", None)
+    monkeypatch.setattr(imagery, "_last_remote_request_at", None)
     monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
 
     first_dir = tmp_path / "first"


### PR DESCRIPTION
## Summary
- disable the hard 50-tile guard by letting MAX_TILES_PER_RUN be unset
- track the last network call so cached tiles bypass the 5-second wait
- update UI copy, documentation, and tests to reflect the relaxed limits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce8b7e66108327be9add786b44f3fa